### PR TITLE
Unset QEMU AUDIO DRV to fix issues with openSUSE

### DIFF
--- a/app.xemu.xemu.yml
+++ b/app.xemu.xemu.yml
@@ -12,6 +12,7 @@ finish-args:
   - --socket=x11
   - --share=ipc
   - --unset-env=QEMU_AUDIO_DRV
+# --unset-env=QEMU_AUDIO_DRV fixes issues with openSUSE systems, QEMU_AUDIO_DRV is defined as "pa" causing xemu to not launch
 
 modules:
   - name: libpcap

--- a/app.xemu.xemu.yml
+++ b/app.xemu.xemu.yml
@@ -11,6 +11,7 @@ finish-args:
   - --socket=pulseaudio
   - --socket=x11
   - --share=ipc
+  - --unset-env=QEMU_AUDIO_DRV
 
 modules:
   - name: libpcap


### PR DESCRIPTION
Xemu refuses to run on openSUSE without using run arg `flatpak run --unset-env=QEMU_AUDIO_DRV app.xemu.xemu`

This will fix the flatpak from needing this work around on openSUSE and any system that also has this issue.

```
tyler@fedora:~> flatpak run --unset-env=QEMU_AUDIO_DRV app.xemu.xemu
xemu_version: 0.7.25
xemu_branch: 7d6da227ba3b224647e35d2385419a3bec25a3b3
xemu_commit: 7d6da227ba3b224647e35d2385419a3bec25a3b3
xemu_date: Tue May 31 02:10:48 AM UTC 2022
xemu_settings_get_path: config path: /home/tyler/.var/app/app.xemu.xemu/data/xemu/xemu/xemu.toml
CPU: AMD Ryzen 7 2700 Eight-Core Processor          
OS_Version: Freedesktop.org 21.08.14 (Flatpak runtime)
GL_VENDOR: AMD
GL_RENDERER: Radeon RX 580 Series (POLARIS10, DRM 3.44.0, 5.17.9-1-default, LLVM 12.0.1)
GL_VERSION: 4.6 (Core Profile) Mesa 21.3.8 (git-813ee839be)
GL_SHADING_LANGUAGE_VERSION: 4.60
Created QEMU launch parameters: xemu -machine xbox,bootrom
(rest of usual info, application runs)
```
```
tyler@fedora:~> flatpak run app.xemu.xemu
xemu_version: 0.7.25
xemu_branch: 7d6da227ba3b224647e35d2385419a3bec25a3b3
xemu_commit: 7d6da227ba3b224647e35d2385419a3bec25a3b3
xemu_date: Tue May 31 02:10:48 AM UTC 2022
xemu_settings_get_path: config path: /home/tyler/.var/app/app.xemu.xemu/data/xemu/xemu/xemu.toml
CPU: AMD Ryzen 7 2700 Eight-Core Processor          
OS_Version: Freedesktop.org 21.08.14 (Flatpak runtime)
GL_VENDOR: AMD
GL_RENDERER: Radeon RX 580 Series (POLARIS10, DRM 3.44.0, 5.17.9-1-default, LLVM 12.0.1)
GL_VERSION: 4.6 (Core Profile) Mesa 21.3.8 (git-813ee839be)
GL_SHADING_LANGUAGE_VERSION: 4.60
Created QEMU launch parameters: xemu -machine xbox,bootrom
audio-legacy: Unknown audio driver `pa'
(Crashes)
```